### PR TITLE
Custom name for uploaded files

### DIFF
--- a/space-upload.py
+++ b/space-upload.py
@@ -51,7 +51,7 @@ with open("password.json", "r") as file:
         
     # Get the list of files 
     
-    response = cli:nt.list_objects_v2(
+    response = client.list_objects_v2(
         Bucket='tcb-drone',
         Delimiter=' ',
         EncodingType='url'


### PR DESCRIPTION
This change allows users to name the file they upload instead of using their local path as the name